### PR TITLE
Fix README typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,4 +176,4 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
-This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind are welcome!


### PR DESCRIPTION
**What the PR does**

Add the missing word `are` in the README message `Contributions of any kind welcome!`

**Description**

There is a typo in the current README for the project as shown in the screenshot below.

![typo](https://user-images.githubusercontent.com/27225249/66141369-3f72e080-e60c-11e9-818e-104a020f7a0a.png)

It should be, *Contribution of any kind are welcome!*